### PR TITLE
CI: remove unused check_skip steps

### DIFF
--- a/.github/workflows/aux_tests.yml
+++ b/.github/workflows/aux_tests.yml
@@ -7,12 +7,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
-  check_skip:
-    runs-on: ubuntu-latest
-    if: "! contains(github.event.head_commit.message, '[ci skip]')"
-    steps:
-      - run: echo "${{ github.event.head_commit.message }}"
-
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/data_tests.yml
+++ b/.github/workflows/data_tests.yml
@@ -7,12 +7,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
-  check_skip:
-    runs-on: ubuntu-latest
-    if: "! contains(github.event.head_commit.message, '[ci skip]')"
-    steps:
-      - run: echo "${{ github.event.head_commit.message }}"
-
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/inference_tests.yml
+++ b/.github/workflows/inference_tests.yml
@@ -7,12 +7,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
-  check_skip:
-    runs-on: ubuntu-latest
-    if: "! contains(github.event.head_commit.message, '[ci skip]')"
-    steps:
-      - run: echo "${{ github.event.head_commit.message }}"
-
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -7,12 +7,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
-  check_skip:
-    runs-on: ubuntu-latest
-    if: "! contains(github.event.head_commit.message, '[ci skip]')"
-    steps:
-      - run: echo "${{ github.event.head_commit.message }}"
-
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/text_tests.yml
+++ b/.github/workflows/text_tests.yml
@@ -7,12 +7,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
-  check_skip:
-    runs-on: ubuntu-latest
-    if: "! contains(github.event.head_commit.message, '[ci skip]')"
-    steps:
-      - run: echo "${{ github.event.head_commit.message }}"
-
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/tts_tests.yml
+++ b/.github/workflows/tts_tests.yml
@@ -7,12 +7,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
-  check_skip:
-    runs-on: ubuntu-latest
-    if: "! contains(github.event.head_commit.message, '[ci skip]')"
-    steps:
-      - run: echo "${{ github.event.head_commit.message }}"
-
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/tts_tests2.yml
+++ b/.github/workflows/tts_tests2.yml
@@ -7,12 +7,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
-  check_skip:
-    runs-on: ubuntu-latest
-    if: "! contains(github.event.head_commit.message, '[ci skip]')"
-    steps:
-      - run: echo "${{ github.event.head_commit.message }}"
-
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/vocoder_tests.yml
+++ b/.github/workflows/vocoder_tests.yml
@@ -7,12 +7,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
-  check_skip:
-    runs-on: ubuntu-latest
-    if: "! contains(github.event.head_commit.message, '[ci skip]')"
-    steps:
-      - run: echo "${{ github.event.head_commit.message }}"
-
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/xtts_tests.yml
+++ b/.github/workflows/xtts_tests.yml
@@ -7,12 +7,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
-  check_skip:
-    runs-on: ubuntu-latest
-    if: "! contains(github.event.head_commit.message, '[ci skip]')"
-    steps:
-      - run: echo "${{ github.event.head_commit.message }}"
-
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/zoo_tests0.yml
+++ b/.github/workflows/zoo_tests0.yml
@@ -7,12 +7,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
-  check_skip:
-    runs-on: ubuntu-latest
-    if: "! contains(github.event.head_commit.message, '[ci skip]')"
-    steps:
-      - run: echo "${{ github.event.head_commit.message }}"
-
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/zoo_tests1.yml
+++ b/.github/workflows/zoo_tests1.yml
@@ -7,12 +7,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
-  check_skip:
-    runs-on: ubuntu-latest
-    if: "! contains(github.event.head_commit.message, '[ci skip]')"
-    steps:
-      - run: echo "${{ github.event.head_commit.message }}"
-
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/zoo_tests2.yml
+++ b/.github/workflows/zoo_tests2.yml
@@ -7,12 +7,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
-  check_skip:
-    runs-on: ubuntu-latest
-    if: "! contains(github.event.head_commit.message, '[ci skip]')"
-    steps:
-      - run: echo "${{ github.event.head_commit.message }}"
-
   test:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Copied from https://github.com/coqui-ai/TTS/pull/3129:

> There is nothing in the repo that would refer to them.
> 
> They were added in [d43a46c](https://github.com/coqui-ai/TTS/commit/d43a46cc96f64426dd7e5c89be9f0e14ee042a0a) by erogol and probably just copy-pasted onwards from there.

As this PR shows, CI is still skipped when adding `[ci skip]` to the commit message.