### PR TITLE
fix(api): handle missing attribute in is_multi_lingual

### DIFF
--- a/TTS/api.py
+++ b/TTS/api.py
@@ -97,7 +97,7 @@ class TTS(nn.Module):
             isinstance(self.model_name, str)
             and "xtts" in self.model_name
             or self.config
-            and ("xtts" in self.config.model or len(self.config.languages) > 1)
+            and ("xtts" in self.config.model or "languages" in self.config and len(self.config.languages) > 1)
         ):
             return True
         if hasattr(self.synthesizer.tts_model, "language_manager") and self.synthesizer.tts_model.language_manager:

--- a/TTS/tts/datasets/dataset.py
+++ b/TTS/tts/datasets/dataset.py
@@ -4,6 +4,7 @@ import os
 import random
 from typing import Dict, List, Union
 
+import mutagen
 import numpy as np
 import torch
 import tqdm
@@ -12,8 +13,6 @@ from torch.utils.data import Dataset
 from TTS.tts.utils.data import prepare_data, prepare_stop_target, prepare_tensor
 from TTS.utils.audio import AudioProcessor
 from TTS.utils.audio.numpy_transforms import compute_energy as calculate_energy
-
-import mutagen
 
 # to prevent too many open files error as suggested here
 # https://github.com/pytorch/pytorch/issues/11201#issuecomment-421146936
@@ -47,7 +46,9 @@ def string2filename(string):
 def get_audio_size(audiopath):
     extension = audiopath.rpartition(".")[-1].lower()
     if extension not in {"mp3", "wav", "flac"}:
-        raise RuntimeError(f"The audio format {extension} is not supported, please convert the audio files to mp3, flac, or wav format!")
+        raise RuntimeError(
+            f"The audio format {extension} is not supported, please convert the audio files to mp3, flac, or wav format!"
+        )
 
     audio_info = mutagen.File(audiopath).info
     return int(audio_info.length * audio_info.sample_rate)


### PR DESCRIPTION
Copied from https://github.com/coqui-ai/TTS/pull/3450:
> Fixes #3449, i.e. the following works again:
> 
> ```python
> from TTS.api import TTS
> 
> cloud = TTS(model_name="tts_models/de/thorsten/vits")  # just to download the model
> _ = cloud.tts("test")  # this works fine
> 
> from TTS.utils.generic_utils import get_user_data_dir
> model = os.path.join(get_user_data_dir("tts"), "tts_models--de--thorsten--vits", "model_file.pth")
> config = os.path.join(get_user_data_dir("tts"), "tts_models--de--thorsten--vits", "config.json")
> local = TTS(model_path=model, config_path=config)
> _ = local.tts("test")  # this failed previously
> ```

Also fixes https://github.com/coqui-ai/TTS/issues/3602