### PR TITLE
Fix TTS().list_models()

### DIFF
--- a/TTS/api.py
+++ b/TTS/api.py
@@ -122,8 +122,9 @@ class TTS(nn.Module):
     def get_models_file_path():
         return Path(__file__).parent / ".models.json"
 
-    def list_models(self):
-        return ModelManager(models_file=TTS.get_models_file_path(), progress_bar=False, verbose=False)
+    @staticmethod
+    def list_models():
+        return ModelManager(models_file=TTS.get_models_file_path(), progress_bar=False, verbose=False).list_models()
 
     def download_model_by_name(self, model_name: str):
         model_path, config_path, model_item = self.manager.download_model(model_name)


### PR DESCRIPTION
Copied from https://github.com/coqui-ai/TTS/pull/3422 (fixes https://github.com/coqui-ai/TTS/issues/3427, fixes https://github.com/coqui-ai/TTS/issues/3429, obsoletes https://github.com/coqui-ai/TTS/pull/3597, https://github.com/coqui-ai/TTS/pull/3622):
> ```python
> from TTS.api import TTS
> print(TTS().list_models())
> ```
> 
> This currently throws an error because TTS.list_models() returns the ModelManager Fix by calling list_models() on the model manager
> 
> I'm unsure if the functionality of TTS.list_models() was to return the ModelManager object, but this used to return a list of model names and currently does not.

