### PR TITLE
fix(xtts_manager): name_to_id() should return dict

### DIFF
--- a/TTS/tts/layers/xtts/xtts_manager.py
+++ b/TTS/tts/layers/xtts/xtts_manager.py
@@ -7,7 +7,7 @@ class SpeakerManager:
 
     @property
     def name_to_id(self):
-        return self.speakers.keys()
+        return self.speakers
 
     @property
     def num_speakers(self):


### PR DESCRIPTION
Fixes https://github.com/coqui-ai/TTS/issues/3527, fixes https://github.com/coqui-ai/TTS/issues/3456, supersedes https://github.com/coqui-ai/TTS/pull/3487 (for consistency with other speaker managers the `.keys()` should be removed in `name_to_id()`)