### PR TITLE
Fix fairseq

### DIFF
--- a/TTS/utils/manage.py
+++ b/TTS/utils/manage.py
@@ -270,6 +270,7 @@ class ModelManager(object):
                 "description": "this model is released by Meta under Fairseq repo. Visit https://github.com/facebookresearch/fairseq/tree/main/examples/mms for more info.",
             }
             model_item["model_name"] = model_name
+            model_type, lang, dataset, model = model_name.split("/")
         elif "xtts" in model_name and len(model_name.split("/")) != 4:
             # loading xtts models with only model name (e.g. xtts_v2.0.2)
             # check model name has the version number with regex

--- a/TTS/utils/manage.py
+++ b/TTS/utils/manage.py
@@ -260,8 +260,7 @@ class ModelManager(object):
     def _set_model_item(self, model_name):
         # fetch model info from the dict
         if "fairseq" in model_name:
-            model_type = "tts_models"
-            lang = model_name.split("/")[1]
+            model_type, lang, dataset, model = model_name.split("/")
             model_item = {
                 "model_type": "tts_models",
                 "license": "CC BY-NC 4.0",
@@ -270,7 +269,6 @@ class ModelManager(object):
                 "description": "this model is released by Meta under Fairseq repo. Visit https://github.com/facebookresearch/fairseq/tree/main/examples/mms for more info.",
             }
             model_item["model_name"] = model_name
-            model_type, lang, dataset, model = model_name.split("/")
         elif "xtts" in model_name and len(model_name.split("/")) != 4:
             # loading xtts models with only model name (e.g. xtts_v2.0.2)
             # check model name has the version number with regex


### PR DESCRIPTION
Copied from https://github.com/coqui-ai/TTS/pull/3502 (supersedes https://github.com/coqui-ai/TTS/pull/3500 and https://github.com/coqui-ai/TTS/pull/3471, fixes https://github.com/coqui-ai/TTS/issues/3142, fixes https://github.com/coqui-ai/TTS/issues/3361, fixes https://github.com/coqui-ai/TTS/issues/3501, fixes https://github.com/coqui-ai/TTS/issues/3638):
> #### Fix error on using `fairseq` model. Variables like `dataset` and `model` aren't defined.
> 
> So, this is the bug a user faced recently while using the model `fairseq`, as you can see the user encountered the error: **unbound variable 'dataset'** in the file `manage.py` in the method ` _set_model_item`, on inspecting the code, I found that infact, in the condition when fairseq was in 'model_name' there was no declaration of variable `dataset` as well as the variable `model`, so I just added them in the first if condition and it solved the issue. I tested it and it worked like charm.
> #### Code:
> 
> ```python
> from TTS.api import TTS
> 
> tts = TTS(model_name="tts_models/eng/fairseq/vits", progress_bar=False, gpu=True)
> tts.tts_to_file("This is a test.", file_path="output.wav")
> ```
> 
> #### Error:
> 
> ```shell
> D:\Software\anaconda3\envs\freqtrade310\python.exe C:\Users\uyplayer\Downloads\uig-script_arabic\model.py 
> D:\Software\anaconda3\envs\freqtrade310\lib\site-packages\TTS\api.py:70: UserWarning: `gpu` will be deprecated. Please use `tts.to(device)` instead.
>   warnings.warn("`gpu` will be deprecated. Please use `tts.to(device)` instead.")
> Traceback (most recent call last):
>   File "C:\Users\uyplayer\Downloads\uig-script_arabic\model.py", line 5, in <module>
>     tts = TTS(model_name="tts_models/eng/fairseq/vits", progress_bar=False, gpu=True)
>   File "D:\Software\anaconda3\envs\freqtrade310\lib\site-packages\TTS\api.py", line 74, in __init__
>     self.load_tts_model_by_name(model_name, gpu)
>   File "D:\Software\anaconda3\envs\freqtrade310\lib\site-packages\TTS\api.py", line 171, in load_tts_model_by_name
>     model_path, config_path, vocoder_path, vocoder_config_path, model_dir = self.download_model_by_name(
>   File "D:\Software\anaconda3\envs\freqtrade310\lib\site-packages\TTS\api.py", line 129, in download_model_by_name
>     model_path, config_path, model_item = self.manager.download_model(model_name)
>   File "D:\Software\anaconda3\envs\freqtrade310\lib\site-packages\TTS\utils\manage.py", line 385, in download_model
>     model_item, model_full_name, model, md5sum = self._set_model_item(model_name)
>   File "D:\Software\anaconda3\envs\freqtrade310\lib\site-packages\TTS\utils\manage.py", line 304, in _set_model_item
>     model_full_name = f"{model_type}--{lang}--{dataset}--{model}"
> UnboundLocalError: local variable 'dataset' referenced before assignment
> 
> Process finished with exit code 1
> ```
> 
> fixes: #3142 #3361 #3501
> 
> Since this is my first PR, It would be really nice if it would get merged, or if there's anything else I can help with please let me know. ThankYou.