### PR TITLE
ci: switch from pip to uv

### DIFF
--- a/.github/workflows/aux_tests.yml
+++ b/.github/workflows/aux_tests.yml
@@ -33,13 +33,13 @@ jobs:
           sudo apt-get install -y git make gcc
           make system-deps
       - name: Install/upgrade Python setup deps
-        run: python3 -m pip install --upgrade pip setuptools wheel
+        run: python3 -m pip install --upgrade pip setuptools wheel uv
       - name: Replace scarf urls
         run: |
           sed -i 's/https:\/\/coqui.gateway.scarf.sh\//https:\/\/github.com\/coqui-ai\/TTS\/releases\/download\//g' TTS/.models.json
       - name: Install TTS
         run: |
-          python3 -m pip install .[all]
+          python3 -m uv pip install --system "TTS[all] @ ."
           python3 setup.py egg_info
       - name: Unit tests
         run: make test_aux

--- a/.github/workflows/data_tests.yml
+++ b/.github/workflows/data_tests.yml
@@ -33,13 +33,13 @@ jobs:
           sudo apt-get install -y --no-install-recommends git make gcc
           make system-deps
       - name: Install/upgrade Python setup deps
-        run: python3 -m pip install --upgrade pip setuptools wheel
+        run: python3 -m pip install --upgrade pip setuptools wheel uv
       - name: Replace scarf urls
         run: |
           sed -i 's/https:\/\/coqui.gateway.scarf.sh\//https:\/\/github.com\/coqui-ai\/TTS\/releases\/download\//g' TTS/.models.json
       - name: Install TTS
         run: |
-          python3 -m pip install .[all]
+          python3 -m uv pip install --system "TTS[all] @ ."
           python3 setup.py egg_info
       - name: Unit tests
         run: make data_tests

--- a/.github/workflows/inference_tests.yml
+++ b/.github/workflows/inference_tests.yml
@@ -35,13 +35,13 @@ jobs:
           sudo apt-get install espeak-ng
           make system-deps
       - name: Install/upgrade Python setup deps
-        run: python3 -m pip install --upgrade pip setuptools wheel
+        run: python3 -m pip install --upgrade pip setuptools wheel uv
       - name: Replace scarf urls
         run: |
           sed -i 's/https:\/\/coqui.gateway.scarf.sh\//https:\/\/github.com\/coqui-ai\/TTS\/releases\/download\//g' TTS/.models.json
       - name: Install TTS
         run: |
-          python3 -m pip install .[all]
+          python3 -m uv pip install --system "TTS[all] @ ."
           python3 setup.py egg_info
       - name: Unit tests
         run: make inference_tests

--- a/.github/workflows/text_tests.yml
+++ b/.github/workflows/text_tests.yml
@@ -35,10 +35,10 @@ jobs:
           sudo apt-get install espeak-ng
           make system-deps
       - name: Install/upgrade Python setup deps
-        run: python3 -m pip install --upgrade pip setuptools wheel
+        run: python3 -m pip install --upgrade pip setuptools wheel uv
       - name: Install TTS
         run: |
-          python3 -m pip install .[all]
+          python3 -m uv pip install --system "TTS[all] @ ."
           python3 setup.py egg_info
       - name: Unit tests
         run: make test_text

--- a/.github/workflows/tts_tests.yml
+++ b/.github/workflows/tts_tests.yml
@@ -35,13 +35,13 @@ jobs:
           sudo apt-get install espeak-ng
           make system-deps
       - name: Install/upgrade Python setup deps
-        run: python3 -m pip install --upgrade pip setuptools wheel
+        run: python3 -m pip install --upgrade pip setuptools wheel uv
       - name: Replace scarf urls
         run: |
           sed -i 's/https:\/\/coqui.gateway.scarf.sh\//https:\/\/github.com\/coqui-ai\/TTS\/releases\/download\//g' TTS/.models.json
       - name: Install TTS
         run: |
-          python3 -m pip install .[all]
+          python3 -m uv pip install --system "TTS[all] @ ."
           python3 setup.py egg_info
       - name: Unit tests
         run: make test_tts

--- a/.github/workflows/tts_tests2.yml
+++ b/.github/workflows/tts_tests2.yml
@@ -35,13 +35,13 @@ jobs:
           sudo apt-get install espeak-ng
           make system-deps
       - name: Install/upgrade Python setup deps
-        run: python3 -m pip install --upgrade pip setuptools wheel
+        run: python3 -m pip install --upgrade pip setuptools wheel uv
       - name: Replace scarf urls
         run: |
           sed -i 's/https:\/\/coqui.gateway.scarf.sh\//https:\/\/github.com\/coqui-ai\/TTS\/releases\/download\//g' TTS/.models.json
       - name: Install TTS
         run: |
-          python3 -m pip install .[all]
+          python3 -m uv pip install --system "TTS[all] @ ."
           python3 setup.py egg_info
       - name: Unit tests
         run: make test_tts2

--- a/.github/workflows/vocoder_tests.yml
+++ b/.github/workflows/vocoder_tests.yml
@@ -33,10 +33,10 @@ jobs:
           sudo apt-get install -y git make gcc
           make system-deps
       - name: Install/upgrade Python setup deps
-        run: python3 -m pip install --upgrade pip setuptools wheel
+        run: python3 -m pip install --upgrade pip setuptools wheel uv
       - name: Install TTS
         run: |
-          python3 -m pip install .[all]
+          python3 -m uv pip install --system "TTS[all] @ ."
           python3 setup.py egg_info
       - name: Unit tests
         run: make test_vocoder

--- a/.github/workflows/xtts_tests.yml
+++ b/.github/workflows/xtts_tests.yml
@@ -35,13 +35,13 @@ jobs:
           sudo apt-get install espeak-ng
           make system-deps
       - name: Install/upgrade Python setup deps
-        run: python3 -m pip install --upgrade pip setuptools wheel
+        run: python3 -m pip install --upgrade pip setuptools wheel uv
       - name: Replace scarf urls
         run: |
           sed -i 's/https:\/\/coqui.gateway.scarf.sh\//https:\/\/github.com\/coqui-ai\/TTS\/releases\/download\//g' TTS/.models.json
       - name: Install TTS
         run: |
-          python3 -m pip install .[all]
+          python3 -m uv pip install --system "TTS[all] @ ."
           python3 setup.py egg_info
       - name: Unit tests
         run: make test_xtts

--- a/.github/workflows/zoo_tests0.yml
+++ b/.github/workflows/zoo_tests0.yml
@@ -34,13 +34,13 @@ jobs:
           sudo apt-get install espeak espeak-ng
           make system-deps
       - name: Install/upgrade Python setup deps
-        run: python3 -m pip install --upgrade pip setuptools wheel
+        run: python3 -m pip install --upgrade pip setuptools wheel uv
       - name: Replace scarf urls
         run: |
           sed -i 's/https:\/\/coqui.gateway.scarf.sh\//https:\/\/github.com\/coqui-ai\/TTS\/releases\/download\//g' TTS/.models.json
       - name: Install TTS
         run: |
-          python3 -m pip install .[all]
+          python3 -m uv pip install --system "TTS[all] @ ."
           python3 setup.py egg_info
       - name: Unit tests
         run: |

--- a/.github/workflows/zoo_tests1.yml
+++ b/.github/workflows/zoo_tests1.yml
@@ -34,14 +34,14 @@ jobs:
           sudo apt-get install espeak espeak-ng
           make system-deps
       - name: Install/upgrade Python setup deps
-        run: python3 -m pip install --upgrade pip setuptools wheel
+        run: python3 -m pip install --upgrade pip setuptools wheel uv
       - name: Replace scarf urls
         run: |
           sed -i 's/https:\/\/coqui.gateway.scarf.sh\/hf\/bark\//https:\/\/huggingface.co\/erogol\/bark\/resolve\/main\//g' TTS/.models.json
           sed -i 's/https:\/\/coqui.gateway.scarf.sh\//https:\/\/github.com\/coqui-ai\/TTS\/releases\/download\//g' TTS/.models.json
       - name: Install TTS
         run: |
-          python3 -m pip install .[all]
+          python3 -m uv pip install --system "TTS[all] @ ."
           python3 setup.py egg_info
       - name: Unit tests
         run: nose2 -F -v -B --with-coverage --coverage TTS tests.zoo_tests.test_models.test_models_offset_1_step_3

--- a/.github/workflows/zoo_tests2.yml
+++ b/.github/workflows/zoo_tests2.yml
@@ -34,13 +34,13 @@ jobs:
           sudo apt-get install espeak espeak-ng
           make system-deps
       - name: Install/upgrade Python setup deps
-        run: python3 -m pip install --upgrade pip setuptools wheel
+        run: python3 -m pip install --upgrade pip setuptools wheel uv
       - name: Replace scarf urls
         run: |
           sed -i 's/https:\/\/coqui.gateway.scarf.sh\//https:\/\/github.com\/coqui-ai\/TTS\/releases\/download\//g' TTS/.models.json
       - name: Install TTS
         run: |
-          python3 -m pip install .[all]
+          python3 -m uv pip install --system "TTS[all] @ ."
           python3 setup.py egg_info
       - name: Unit tests
         run: nose2 -F -v -B --with-coverage --coverage TTS tests.zoo_tests.test_models.test_models_offset_2_step_3


### PR DESCRIPTION
Using [uv](https://github.com/astral-sh/uv) in CI reduces package install time from over 3 to less than 1 minute.