### PR TITLE
build: update numpy and librosa

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,11 @@
 # core deps
-numpy==1.22.0;python_version<="3.10"
-numpy>=1.24.3;python_version>"3.10"
+numpy>=1.24.3
 cython>=0.29.30
 scipy>=1.11.2
 torch>=2.1
 torchaudio
 soundfile>=0.12.0
-librosa>=0.10.0
-numba>=0.57.0
+librosa>=0.10.1
 inflect>=5.6.0
 tqdm>=4.64.1
 anyascii>=0.3.0


### PR DESCRIPTION
Fixes https://github.com/coqui-ai/TTS/issues/3538. The previously pinned numpy and librosa versions for Python 3.9 are incompatible (https://github.com/librosa/librosa/pull/1684)